### PR TITLE
fix: add resolution arguments to VideoSource

### DIFF
--- a/examples/e2ee.py
+++ b/examples/e2ee.py
@@ -11,9 +11,10 @@ TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6Ik
 # ("livekitrocks") this is our shared key, it must match the one used by your clients
 SHARED_KEY = b"livekitrocks"
 
+WIDTH, HEIGHT = 1280, 720
 
 async def draw_cube(source: rtc.VideoSource):
-    W, H, MID_W, MID_H = 1280, 720, 640, 360
+    MID_W, MID_H = 640, 360
     cube_size = 60
     vertices = (
         np.array(
@@ -45,7 +46,7 @@ async def draw_cube(source: rtc.VideoSource):
         [3, 7],
     ]
 
-    frame = rtc.ArgbFrame.create(rtc.VideoFormatType.FORMAT_ARGB, W, H)
+    frame = rtc.ArgbFrame.create(rtc.VideoFormatType.FORMAT_ARGB, WIDTH, HEIGHT)
     arr = np.frombuffer(frame.data, dtype=np.uint8)
     angle = 0
 
@@ -82,8 +83,8 @@ async def draw_cube(source: rtc.VideoSource):
                 )
                 for dx in [-1, 0, 1]:
                     for dy in [-1, 0, 1]:
-                        if 0 <= x + dx < W and 0 <= y + dy < H:
-                            idx = (y + dy) * W * 4 + (x + dx) * 4
+                        if 0 <= x + dx < WIDTH and 0 <= y + dy < HEIGHT:
+                            idx = (y + dy) * WIDTH * 4 + (x + dx) * 4
                             arr[idx : idx + 4] = [255, 255, 255, 255]
 
         f = rtc.VideoFrame(0, rtc.VideoRotation.VIDEO_ROTATION_0, frame.to_i420())
@@ -116,7 +117,7 @@ async def main(room: rtc.Room):
         return False
 
     # publish a track
-    source = rtc.VideoSource()
+    source = rtc.VideoSource(WIDTH, HEIGHT)
     track = rtc.LocalVideoTrack.create_video_track("cube", source)
     options = rtc.TrackPublishOptions()
     options.source = rtc.TrackSource.SOURCE_CAMERA

--- a/examples/publish_hue.py
+++ b/examples/publish_hue.py
@@ -9,9 +9,10 @@ from livekit import rtc
 URL = "ws://localhost:7880"
 TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MDY2MTMyODgsImlzcyI6IkFQSVRzRWZpZFpqclFvWSIsIm5hbWUiOiJuYXRpdmUiLCJuYmYiOjE2NzI2MTMyODgsInN1YiI6Im5hdGl2ZSIsInZpZGVvIjp7InJvb20iOiJ0ZXN0Iiwicm9vbUFkbWluIjp0cnVlLCJyb29tQ3JlYXRlIjp0cnVlLCJyb29tSm9pbiI6dHJ1ZSwicm9vbUxpc3QiOnRydWV9fQ.uSNIangMRu8jZD5mnRYoCHjcsQWCrJXgHCs0aNIgBFY"  # noqa
 
+WIDTH, HEIGHT = 1280, 720
 
 async def draw_color_cycle(source: rtc.VideoSource):
-    argb_frame = rtc.ArgbFrame.create(rtc.VideoFormatType.FORMAT_ARGB, 1280, 720)
+    argb_frame = rtc.ArgbFrame.create(rtc.VideoFormatType.FORMAT_ARGB, WIDTH, HEIGHT)
     arr = np.frombuffer(argb_frame.data, dtype=np.uint8)
 
     framerate = 1 / 30
@@ -50,7 +51,7 @@ async def main(room: rtc.Room):
         return
 
     # publish a track
-    source = rtc.VideoSource()
+    source = rtc.VideoSource(WIDTH, HEIGHT)
     track = rtc.LocalVideoTrack.create_video_track("hue", source)
     options = rtc.TrackPublishOptions()
     options.source = rtc.TrackSource.SOURCE_CAMERA

--- a/livekit-rtc/livekit/rtc/video_source.py
+++ b/livekit-rtc/livekit/rtc/video_source.py
@@ -19,11 +19,13 @@ from .video_frame import VideoFrame
 
 
 class VideoSource:
-    def __init__(self) -> None:
+    def __init__(self, width: int, height: int) -> None:
         req = proto_ffi.FfiRequest()
         req.new_video_source.type = (
             proto_video_frame.VideoSourceType.VIDEO_SOURCE_NATIVE
         )
+        req.new_video_source.resolution.width = width
+        req.new_video_source.resolution.height = height
 
         resp = ffi_client.request(req)
         self._info = resp.new_video_source.source


### PR DESCRIPTION
Fix #85 
The VideoSource resolution is used on the Rust side to define the needed simulcast layers