### PR TITLE
sjporta: simple sync methods for api clients

### DIFF
--- a/livekit-api/livekit/api/egress_service.py
+++ b/livekit-api/livekit/api/egress_service.py
@@ -110,3 +110,102 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
+
+    def sync_start_room_composite_egress(
+        self, start: proto_egress.RoomCompositeEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StartRoomCompositeEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_start_web_egress(
+        self, start: proto_egress.WebEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StartWebEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_start_participant_egress(
+        self, start: proto_egress.ParticipantEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StartParticipantEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_start_track_composite_egress(
+        self, start: proto_egress.TrackCompositeEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StartTrackCompositeEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_start_track_egress(
+        self, start: proto_egress.TrackEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StartTrackEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_update_layout(
+        self, update: proto_egress.UpdateLayoutRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "UpdateLayout",
+            update,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_update_stream(
+        self, update: proto_egress.UpdateStreamRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "UpdateStream",
+            update,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )
+    
+    def sync_list_egress(
+        self, list: proto_egress.ListEgressRequest
+    ) -> proto_egress.ListEgressResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListEgress",
+            list,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.ListEgressResponse,
+        )
+    
+    def sync_stop_egress(
+        self, stop: proto_egress.StopEgressRequest
+    ) -> proto_egress.EgressInfo:
+        return self._client.sync_request(
+            SVC,
+            "StopEgress",
+            stop,
+            self._auth_header(VideoGrants(room_record=True)),
+            proto_egress.EgressInfo,
+        )

--- a/livekit-api/livekit/api/egress_service.py
+++ b/livekit-api/livekit/api/egress_service.py
@@ -121,7 +121,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_start_web_egress(
         self, start: proto_egress.WebEgressRequest
     ) -> proto_egress.EgressInfo:
@@ -132,7 +132,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_start_participant_egress(
         self, start: proto_egress.ParticipantEgressRequest
     ) -> proto_egress.EgressInfo:
@@ -143,7 +143,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_start_track_composite_egress(
         self, start: proto_egress.TrackCompositeEgressRequest
     ) -> proto_egress.EgressInfo:
@@ -154,7 +154,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_start_track_egress(
         self, start: proto_egress.TrackEgressRequest
     ) -> proto_egress.EgressInfo:
@@ -165,7 +165,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_update_layout(
         self, update: proto_egress.UpdateLayoutRequest
     ) -> proto_egress.EgressInfo:
@@ -176,7 +176,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_update_stream(
         self, update: proto_egress.UpdateStreamRequest
     ) -> proto_egress.EgressInfo:
@@ -187,7 +187,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.EgressInfo,
         )
-    
+
     def sync_list_egress(
         self, list: proto_egress.ListEgressRequest
     ) -> proto_egress.ListEgressResponse:
@@ -198,7 +198,7 @@ class EgressService(Service):
             self._auth_header(VideoGrants(room_record=True)),
             proto_egress.ListEgressResponse,
         )
-    
+
     def sync_stop_egress(
         self, stop: proto_egress.StopEgressRequest
     ) -> proto_egress.EgressInfo:

--- a/livekit-api/livekit/api/ingress_service.py
+++ b/livekit-api/livekit/api/ingress_service.py
@@ -55,3 +55,47 @@ class IngressService(Service):
             self._auth_header(VideoGrants(ingress_admin=True)),
             proto_ingress.IngressInfo,
         )
+
+    def sync_create_ingress(
+        self, create: proto_ingress.CreateIngressRequest
+    ):
+        return self._client.sync_request(
+            SVC,
+            "CreateIngress",
+            create,
+            self._auth_header(VideoGrants(ingress_admin=True)),
+            proto_ingress.IngressInfo,
+        )
+    
+    def sync_update_ingress(
+        self, update: proto_ingress.UpdateIngressRequest
+    ):
+        return self._client.sync_request(
+            SVC,
+            "UpdateIngress",
+            update,
+            self._auth_header(VideoGrants(ingress_admin=True)),
+            proto_ingress.IngressInfo,
+        )
+    
+    def sync_list_ingress(
+        self, list: proto_ingress.ListIngressRequest
+    ):
+        return self._client.sync_request(
+            SVC,
+            "ListIngress",
+            list,
+            self._auth_header(VideoGrants(ingress_admin=True)),
+            proto_ingress.ListIngressResponse,
+        )
+    
+    def sync_delete_ingress(
+        self, delete: proto_ingress.DeleteIngressRequest
+    ):
+        return self._client.sync_request(
+            SVC,
+            "DeleteIngress",
+            delete,
+            self._auth_header(VideoGrants(ingress_admin=True)),
+            proto_ingress.IngressInfo,
+        )

--- a/livekit-api/livekit/api/ingress_service.py
+++ b/livekit-api/livekit/api/ingress_service.py
@@ -56,9 +56,7 @@ class IngressService(Service):
             proto_ingress.IngressInfo,
         )
 
-    def sync_create_ingress(
-        self, create: proto_ingress.CreateIngressRequest
-    ):
+    def sync_create_ingress(self, create: proto_ingress.CreateIngressRequest):
         return self._client.sync_request(
             SVC,
             "CreateIngress",
@@ -66,10 +64,8 @@ class IngressService(Service):
             self._auth_header(VideoGrants(ingress_admin=True)),
             proto_ingress.IngressInfo,
         )
-    
-    def sync_update_ingress(
-        self, update: proto_ingress.UpdateIngressRequest
-    ):
+
+    def sync_update_ingress(self, update: proto_ingress.UpdateIngressRequest):
         return self._client.sync_request(
             SVC,
             "UpdateIngress",
@@ -77,10 +73,8 @@ class IngressService(Service):
             self._auth_header(VideoGrants(ingress_admin=True)),
             proto_ingress.IngressInfo,
         )
-    
-    def sync_list_ingress(
-        self, list: proto_ingress.ListIngressRequest
-    ):
+
+    def sync_list_ingress(self, list: proto_ingress.ListIngressRequest):
         return self._client.sync_request(
             SVC,
             "ListIngress",
@@ -88,10 +82,8 @@ class IngressService(Service):
             self._auth_header(VideoGrants(ingress_admin=True)),
             proto_ingress.ListIngressResponse,
         )
-    
-    def sync_delete_ingress(
-        self, delete: proto_ingress.DeleteIngressRequest
-    ):
+
+    def sync_delete_ingress(self, delete: proto_ingress.DeleteIngressRequest):
         return self._client.sync_request(
             SVC,
             "DeleteIngress",

--- a/livekit-api/livekit/api/room_service.py
+++ b/livekit-api/livekit/api/room_service.py
@@ -145,7 +145,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_create=True)),
             proto_models.Room,
         )
-    
+
     def sync_delete_room(
         self, delete: proto_room.DeleteRoomRequest
     ) -> proto_room.DeleteRoomResponse:
@@ -156,7 +156,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_create=True)),
             proto_room.DeleteRoomResponse,
         )
-    
+
     def sync_update_room_metadata(
         self, update: proto_room.UpdateRoomMetadataRequest
     ) -> proto_models.Room:
@@ -167,7 +167,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=update.room)),
             proto_models.Room,
         )
-    
+
     def sync_remove_participant(
         self, remove: proto_room.RoomParticipantIdentity
     ) -> proto_room.RemoveParticipantResponse:
@@ -178,7 +178,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=remove.room)),
             proto_room.RemoveParticipantResponse,
         )
-    
+
     def sync_mute_published_track(
         self,
         update: proto_room.MuteRoomTrackRequest,
@@ -190,7 +190,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=update.room)),
             proto_room.MuteRoomTrackResponse,
         )
-    
+
     def sync_update_participant(
         self, update: proto_room.UpdateParticipantRequest
     ) -> proto_models.ParticipantInfo:
@@ -201,7 +201,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=update.room)),
             proto_models.ParticipantInfo,
         )
-    
+
     def sync_update_subscriptions(
         self, update: proto_room.UpdateSubscriptionsRequest
     ) -> proto_room.UpdateSubscriptionsResponse:
@@ -212,7 +212,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=update.room)),
             proto_room.UpdateSubscriptionsResponse,
         )
-    
+
     def sync_send_data(
         self, send: proto_room.SendDataRequest
     ) -> proto_room.SendDataResponse:
@@ -223,7 +223,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=send.room)),
             proto_room.SendDataResponse,
         )
-    
+
     def sync_list_participants(
         self, list: proto_room.ListParticipantsRequest
     ) -> proto_room.ListParticipantsResponse:
@@ -234,7 +234,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=list.room)),
             proto_room.ListParticipantsResponse,
         )
-    
+
     def sync_get_participant(
         self, get: proto_room.RoomParticipantIdentity
     ) -> proto_models.ParticipantInfo:
@@ -245,7 +245,7 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=get.room)),
             proto_models.ParticipantInfo,
         )
-    
+
     def sync_list_rooms(
         self, list: proto_room.ListRoomsRequest
     ) -> proto_room.ListRoomsResponse:

--- a/livekit-api/livekit/api/room_service.py
+++ b/livekit-api/livekit/api/room_service.py
@@ -134,3 +134,125 @@ class RoomService(Service):
             self._auth_header(VideoGrants(room_admin=True, room=send.room)),
             proto_room.SendDataResponse,
         )
+
+    def sync_create_room(
+        self, create: proto_room.CreateRoomRequest
+    ) -> proto_models.Room:
+        return self._client.sync_request(
+            SVC,
+            "CreateRoom",
+            create,
+            self._auth_header(VideoGrants(room_create=True)),
+            proto_models.Room,
+        )
+    
+    def sync_delete_room(
+        self, delete: proto_room.DeleteRoomRequest
+    ) -> proto_room.DeleteRoomResponse:
+        return self._client.sync_request(
+            SVC,
+            "DeleteRoom",
+            delete,
+            self._auth_header(VideoGrants(room_create=True)),
+            proto_room.DeleteRoomResponse,
+        )
+    
+    def sync_update_room_metadata(
+        self, update: proto_room.UpdateRoomMetadataRequest
+    ) -> proto_models.Room:
+        return self._client.sync_request(
+            SVC,
+            "UpdateRoomMetadata",
+            update,
+            self._auth_header(VideoGrants(room_admin=True, room=update.room)),
+            proto_models.Room,
+        )
+    
+    def sync_remove_participant(
+        self, remove: proto_room.RoomParticipantIdentity
+    ) -> proto_room.RemoveParticipantResponse:
+        return self._client.sync_request(
+            SVC,
+            "RemoveParticipant",
+            remove,
+            self._auth_header(VideoGrants(room_admin=True, room=remove.room)),
+            proto_room.RemoveParticipantResponse,
+        )
+    
+    def sync_mute_published_track(
+        self,
+        update: proto_room.MuteRoomTrackRequest,
+    ) -> proto_room.MuteRoomTrackResponse:
+        return self._client.sync_request(
+            SVC,
+            "MutePublishedTrack",
+            update,
+            self._auth_header(VideoGrants(room_admin=True, room=update.room)),
+            proto_room.MuteRoomTrackResponse,
+        )
+    
+    def sync_update_participant(
+        self, update: proto_room.UpdateParticipantRequest
+    ) -> proto_models.ParticipantInfo:
+        return self._client.sync_request(
+            SVC,
+            "UpdateParticipant",
+            update,
+            self._auth_header(VideoGrants(room_admin=True, room=update.room)),
+            proto_models.ParticipantInfo,
+        )
+    
+    def sync_update_subscriptions(
+        self, update: proto_room.UpdateSubscriptionsRequest
+    ) -> proto_room.UpdateSubscriptionsResponse:
+        return self._client.sync_request(
+            SVC,
+            "UpdateSubscriptions",
+            update,
+            self._auth_header(VideoGrants(room_admin=True, room=update.room)),
+            proto_room.UpdateSubscriptionsResponse,
+        )
+    
+    def sync_send_data(
+        self, send: proto_room.SendDataRequest
+    ) -> proto_room.SendDataResponse:
+        return self._client.sync_request(
+            SVC,
+            "SendData",
+            send,
+            self._auth_header(VideoGrants(room_admin=True, room=send.room)),
+            proto_room.SendDataResponse,
+        )
+    
+    def sync_list_participants(
+        self, list: proto_room.ListParticipantsRequest
+    ) -> proto_room.ListParticipantsResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListParticipants",
+            list,
+            self._auth_header(VideoGrants(room_admin=True, room=list.room)),
+            proto_room.ListParticipantsResponse,
+        )
+    
+    def sync_get_participant(
+        self, get: proto_room.RoomParticipantIdentity
+    ) -> proto_models.ParticipantInfo:
+        return self._client.sync_request(
+            SVC,
+            "GetParticipant",
+            get,
+            self._auth_header(VideoGrants(room_admin=True, room=get.room)),
+            proto_models.ParticipantInfo,
+        )
+    
+    def sync_list_rooms(
+        self, list: proto_room.ListRoomsRequest
+    ) -> proto_room.ListRoomsResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListRooms",
+            list,
+            self._auth_header(VideoGrants(room_list=True)),
+            proto_room.ListRoomsResponse,
+        )

--- a/livekit-api/livekit/api/sip_service.py
+++ b/livekit-api/livekit/api/sip_service.py
@@ -132,3 +132,124 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(call=True)),
             proto_sip.SIPParticipantInfo,
         )
+
+    def sync_create_sip_trunk(
+        self, create: proto_sip.CreateSIPTrunkRequest
+    ) -> proto_sip.SIPTrunkInfo:
+        return self._client.sync_request(
+            SVC,
+            "CreateSIPTrunk",
+            create,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPTrunkInfo,
+        )
+    
+    def sync_create_sip_inbound_trunk(
+        self, create: proto_sip.CreateSIPInboundTrunkRequest
+    ) -> proto_sip.SIPInboundTrunkInfo:
+        return self._client.sync_request(
+            SVC,
+            "CreateSIPInboundTrunk",
+            create,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPInboundTrunkInfo,
+        )
+    
+    def sync_create_sip_outbound_trunk(
+        self, create: proto_sip.CreateSIPOutboundTrunkRequest
+    ) -> proto_sip.SIPOutboundTrunkInfo:
+        return self._client.sync_request(
+            SVC,
+            "CreateSIPOutboundTrunk",
+            create,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPOutboundTrunkInfo,
+        )
+    
+    def sync_list_sip_trunk(
+        self, list: proto_sip.ListSIPTrunkRequest
+    ) -> proto_sip.ListSIPTrunkResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListSIPTrunk",
+            list,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.ListSIPTrunkResponse,
+        )
+    
+    def sync_list_sip_inbound_trunk(
+        self, list: proto_sip.ListSIPInboundTrunkRequest
+    ) -> proto_sip.ListSIPInboundTrunkResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListSIPInboundTrunk",
+            list,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.ListSIPInboundTrunkResponse,
+        )
+    
+    def sync_list_sip_outbound_trunk(
+        self, list: proto_sip.ListSIPOutboundTrunkRequest
+    ) -> proto_sip.ListSIPOutboundTrunkResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListSIPOutboundTrunk",
+            list,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.ListSIPOutboundTrunkResponse,
+        )
+    
+    def sync_delete_sip_trunk(
+        self, delete: proto_sip.DeleteSIPTrunkRequest
+    ) -> proto_sip.SIPTrunkInfo:
+        return self._client.sync_request(
+            SVC,
+            "DeleteSIPTrunk",
+            delete,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPTrunkInfo,
+        )
+    
+    def sync_create_sip_dispatch_rule(
+        self, create: proto_sip.CreateSIPDispatchRuleRequest
+    ) -> proto_sip.SIPDispatchRuleInfo:
+        return self._client.sync_request(
+            SVC,
+            "CreateSIPDispatchRule",
+            create,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPDispatchRuleInfo,
+        )
+    
+    def sync_list_sip_dispatch_rule(
+        self, list: proto_sip.ListSIPDispatchRuleRequest
+    ) -> proto_sip.ListSIPDispatchRuleResponse:
+        return self._client.sync_request(
+            SVC,
+            "ListSIPDispatchRule",
+            list,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.ListSIPDispatchRuleResponse,
+        )
+    
+    def sync_delete_sip_dispatch_rule(
+        self, delete: proto_sip.DeleteSIPDispatchRuleRequest
+    ) -> proto_sip.SIPDispatchRuleInfo:
+        return self._client.sync_request(
+            SVC,
+            "DeleteSIPDispatchRule",
+            delete,
+            self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
+            proto_sip.SIPDispatchRuleInfo,
+        )
+    
+    def sync_create_sip_participant(
+        self, create: proto_sip.CreateSIPParticipantRequest
+    ) -> proto_sip.SIPParticipantInfo:
+        return self._client.sync_request(
+            SVC,
+            "CreateSIPParticipant",
+            create,
+            self._auth_header(VideoGrants(), sip=SIPGrants(call=True)),
+            proto_sip.SIPParticipantInfo,
+        )

--- a/livekit-api/livekit/api/sip_service.py
+++ b/livekit-api/livekit/api/sip_service.py
@@ -143,7 +143,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPTrunkInfo,
         )
-    
+
     def sync_create_sip_inbound_trunk(
         self, create: proto_sip.CreateSIPInboundTrunkRequest
     ) -> proto_sip.SIPInboundTrunkInfo:
@@ -154,7 +154,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPInboundTrunkInfo,
         )
-    
+
     def sync_create_sip_outbound_trunk(
         self, create: proto_sip.CreateSIPOutboundTrunkRequest
     ) -> proto_sip.SIPOutboundTrunkInfo:
@@ -165,7 +165,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPOutboundTrunkInfo,
         )
-    
+
     def sync_list_sip_trunk(
         self, list: proto_sip.ListSIPTrunkRequest
     ) -> proto_sip.ListSIPTrunkResponse:
@@ -176,7 +176,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.ListSIPTrunkResponse,
         )
-    
+
     def sync_list_sip_inbound_trunk(
         self, list: proto_sip.ListSIPInboundTrunkRequest
     ) -> proto_sip.ListSIPInboundTrunkResponse:
@@ -187,7 +187,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.ListSIPInboundTrunkResponse,
         )
-    
+
     def sync_list_sip_outbound_trunk(
         self, list: proto_sip.ListSIPOutboundTrunkRequest
     ) -> proto_sip.ListSIPOutboundTrunkResponse:
@@ -198,7 +198,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.ListSIPOutboundTrunkResponse,
         )
-    
+
     def sync_delete_sip_trunk(
         self, delete: proto_sip.DeleteSIPTrunkRequest
     ) -> proto_sip.SIPTrunkInfo:
@@ -209,7 +209,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPTrunkInfo,
         )
-    
+
     def sync_create_sip_dispatch_rule(
         self, create: proto_sip.CreateSIPDispatchRuleRequest
     ) -> proto_sip.SIPDispatchRuleInfo:
@@ -220,7 +220,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPDispatchRuleInfo,
         )
-    
+
     def sync_list_sip_dispatch_rule(
         self, list: proto_sip.ListSIPDispatchRuleRequest
     ) -> proto_sip.ListSIPDispatchRuleResponse:
@@ -231,7 +231,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.ListSIPDispatchRuleResponse,
         )
-    
+
     def sync_delete_sip_dispatch_rule(
         self, delete: proto_sip.DeleteSIPDispatchRuleRequest
     ) -> proto_sip.SIPDispatchRuleInfo:
@@ -242,7 +242,7 @@ class SipService(Service):
             self._auth_header(VideoGrants(), sip=SIPGrants(admin=True)),
             proto_sip.SIPDispatchRuleInfo,
         )
-    
+
     def sync_create_sip_participant(
         self, create: proto_sip.CreateSIPParticipantRequest
     ) -> proto_sip.SIPParticipantInfo:

--- a/livekit-api/livekit/api/twirp_client.py
+++ b/livekit-api/livekit/api/twirp_client.py
@@ -101,7 +101,7 @@ class TwirpClient:
                 # when we have an error, Twirp always encode it in json
                 error_data = await resp.json()
                 raise TwirpError(error_data["code"], error_data["msg"])
-            
+
     def sync_request(
         self,
         service: str,
@@ -114,9 +114,7 @@ class TwirpClient:
         headers["Content-Type"] = "application/protobuf"
 
         serialized_data = data.SerializeToString()
-        resp = requests.post(
-            url, headers=headers, data=serialized_data
-        )
+        resp = requests.post(url, headers=headers, data=serialized_data)
         if resp.status == 200:
             return response_class.FromString(resp.data())
         else:


### PR DESCRIPTION
A bit verbose, but I added sync versions of the services, using `requests.post` instead of `with session.post as resp`. This would be small quality of life for us. Open to feedback.