### PR TITLE
update datetime.utcnow() to use UTC timezone-aware object

### DIFF
--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -154,9 +154,9 @@ class AccessToken:
             {
                 "sub": self.identity,
                 "iss": self.api_key,
-                "nbf": calendar.timegm(datetime.datetime.utcnow().utctimetuple()),
+                "nbf": calendar.timegm(datetime.datetime.now(datetime.timezone.utc).utctimetuple()),
                 "exp": calendar.timegm(
-                    (datetime.datetime.utcnow() + self.ttl).utctimetuple()
+                    (datetime.datetime.now(datetime.timezone.utc) + self.ttl).utctimetuple()
                 ),
             }
         )

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -42,7 +42,7 @@ class VideoGrants:
     can_publish_data: bool = True
 
     # TrackSource types that a participant may publish.
-    # When set, it supercedes CanPublish. Only sources explicitly set here can be
+    # When set, it supersedes CanPublish. Only sources explicitly set here can be
     # published
     can_publish_sources: List[str] = dataclasses.field(default_factory=list)
 

--- a/livekit-rtc/livekit/rtc/_proto/ffi_pb2.pyi
+++ b/livekit-rtc/livekit/rtc/_proto/ffi_pb2.pyi
@@ -63,7 +63,7 @@ global___LogLevel = LogLevel
 class FfiRequest(google.protobuf.message.Message):
     """**How is the livekit-ffi working:
     We refer as the ffi server the Rust server that is running the LiveKit client implementation, and we
-    refer as the ffi client the foreign language that commumicates with the ffi server. (e.g Python SDK, Unity SDK, etc...)
+    refer as the ffi client the foreign language that communicates with the ffi server. (e.g. Python SDK, Unity SDK, etc...)
 
     We expose the Rust client implementation of livekit using the protocol defined here.
     Everything starts with a FfiRequest, which is a oneof message that contains all the possible

--- a/livekit-rtc/livekit/rtc/_proto/handle_pb2.pyi
+++ b/livekit-rtc/livekit/rtc/_proto/handle_pb2.pyi
@@ -26,13 +26,13 @@ DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 @typing.final
 class FfiOwnedHandle(google.protobuf.message.Message):
     """# Safety
-    The foreign language is responsable for disposing handles
+    The foreign language is responsible for disposing handles
     Forgetting to dispose the handle may lead to memory leaks
 
     Dropping a handle doesn't necessarily mean that the object is destroyed if it is still used
     on the FfiServer (Atomic reference counting)
 
-    When refering to a handle without owning it, we just use a uint32 without this message. 
+    When referring to a handle without owning it, we just use an uint32 without this message.
     (the variable name is suffixed with "_handle")
     """
 

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -301,7 +301,7 @@ class LocalParticipant(Participant):
         Establishes the participant as a receiver for calls of the specified RPC method.
         Can be used either as a decorator or a regular method.
 
-        The handler will recieve one argument of type `RpcInvocationData` and should return a string response which will be forwarded back to the caller.
+        The handler will receive one argument of type `RpcInvocationData` and should return a string response which will be forwarded back to the caller.
 
         The handler may be synchronous or asynchronous.
 

--- a/livekit-rtc/livekit/rtc/video_frame.py
+++ b/livekit-rtc/livekit/rtc/video_frame.py
@@ -218,7 +218,7 @@ def _get_plane_length(
     type: proto_video.VideoBufferType.ValueType, width: int, height: int
 ) -> int:
     """
-    Return the size in bytes of a participar video buffer type based on its size (This ignore the strides)
+    Return the size in bytes of a participant video buffer type based on its size (This ignores the strides)
     """
     if type in [
         proto_video.VideoBufferType.ARGB,


### PR DESCRIPTION
Following deprecation warning was raised:
```
  /usr/local/lib/python3.12/site-packages/livekit/api/access_token.py:152: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    (datetime.datetime.utcnow() + self.ttl).utctimetuple()
```

datetime.utcnow() is being deprecated in Python 3.12 as it returns a naive datetime object without timezone information. Replace with datetime.now(UTC) to use an explicit timezone-aware object, preventing potential timezone ambiguity issues.

In access_token.py, updated the token expiration calculation to use the recommended timezone-aware approach.