### PR TITLE
Raise error if EventEmitter used with async callback

### DIFF
--- a/examples/participant_attributes.py
+++ b/examples/participant_attributes.py
@@ -24,7 +24,7 @@ async def main(room: rtc.Room) -> None:
     )
 
     @room.on("participant_attributes_changed")
-    def on_participant_attributes_changed(
+    async def on_participant_attributes_changed(
         changed_attributes: dict[str, str], participant: rtc.Participant
     ):
         logging.info(

--- a/examples/participant_attributes.py
+++ b/examples/participant_attributes.py
@@ -24,7 +24,7 @@ async def main(room: rtc.Room) -> None:
     )
 
     @room.on("participant_attributes_changed")
-    async def on_participant_attributes_changed(
+    def on_participant_attributes_changed(
         changed_attributes: dict[str, str], participant: rtc.Participant
     ):
         logging.info(

--- a/livekit-rtc/livekit/rtc/event_emitter.py
+++ b/livekit-rtc/livekit/rtc/event_emitter.py
@@ -1,4 +1,5 @@
 import inspect
+import asyncio
 from typing import Callable, Dict, Set, Optional, Generic, TypeVar
 
 from .log import logger
@@ -156,6 +157,11 @@ class EventEmitter(Generic[T_contra]):
             ```
         """
         if callback is not None:
+            if asyncio.iscoroutinefunction(callback):
+                raise ValueError(
+                    "Cannot register an async callback with `.on()`. Use `asyncio.create_task` within your synchronous callback instead."
+                )
+
             if event not in self._events:
                 self._events[event] = set()
             self._events[event].add(callback)

--- a/livekit-rtc/tests/test_emitter.py
+++ b/livekit-rtc/tests/test_emitter.py
@@ -51,35 +51,30 @@ def test_args():
 
     emitter = EventEmitter[EventTypes]()
 
-    calls = []
+    args_calls = []
 
-    @emitter.on("whatever")
+    @emitter.on("whatever_args")
     def on_whatever(first, second, third):
-        calls.append((first, second, third))
+        args_calls.append((first, second, third))
 
-    emitter.emit("whatever", 1, 2, 3)
-    emitter.emit("whatever", 1, 2, 3, 4, 5)  # only 3 arguments will be passed
+    emitter.emit("whatever_args", 1, 2, 3)
+    emitter.emit("whatever_args", 1, 2, 3, 4, 5)  # only 3 arguments will be passed
 
-    assert len(calls) == 2
-    assert calls[0] == (1, 2, 3)
-    assert calls[1] == (1, 2, 3)
-
-    calls = []
+    assert args_calls == [(1, 2, 3), (1, 2, 3)]
 
     with pytest.raises(TypeError):
-        emitter.emit("whatever", 1, 2)
+        emitter.emit("whatever_args", 1, 2)
 
-    assert len(calls) == 0
+    varargs_calls = []
 
-    @emitter.on("whatever")
+    @emitter.on("whatever_varargs")
     def on_whatever_varargs(*args):
-        calls.append(args)
+        varargs_calls.append(args)
 
-    emitter.emit("whatever", 1, 2, 3, 4, 5)
+    emitter.emit("whatever_varargs", 1, 2, 3, 4, 5)
+    emitter.emit("whatever_varargs", 1, 2)
 
-    assert len(calls) == 2
-    assert calls[0] == (1, 2, 3)
-    assert calls[1] == (1, 2, 3, 4, 5)
+    assert varargs_calls == [(1, 2, 3, 4, 5), (1, 2)]
 
 
 def test_throw():

--- a/livekit-rtc/tests/test_emitter.py
+++ b/livekit-rtc/tests/test_emitter.py
@@ -53,26 +53,32 @@ def test_args():
 
     args_calls = []
 
-    @emitter.on("whatever_args")
+    @emitter.on("whatever")
     def on_whatever(first, second, third):
         args_calls.append((first, second, third))
 
-    emitter.emit("whatever_args", 1, 2, 3)
-    emitter.emit("whatever_args", 1, 2, 3, 4, 5)  # only 3 arguments will be passed
+    emitter.emit("whatever", 1, 2, 3)
+    emitter.emit("whatever", 1, 2, 3, 4, 5)  # only 3 arguments will be passed
 
     assert args_calls == [(1, 2, 3), (1, 2, 3)]
 
     with pytest.raises(TypeError):
-        emitter.emit("whatever_args", 1, 2)
+        emitter.emit("whatever", 1, 2)
+
+
+def test_varargs():
+    EventTypes = Literal["whatever"]
+
+    emitter = EventEmitter[EventTypes]()
 
     varargs_calls = []
 
-    @emitter.on("whatever_varargs")
+    @emitter.on("whatever")
     def on_whatever_varargs(*args):
         varargs_calls.append(args)
 
-    emitter.emit("whatever_varargs", 1, 2, 3, 4, 5)
-    emitter.emit("whatever_varargs", 1, 2)
+    emitter.emit("whatever", 1, 2, 3, 4, 5)
+    emitter.emit("whatever", 1, 2)
 
     assert varargs_calls == [(1, 2, 3, 4, 5), (1, 2)]
 

--- a/livekit-rtc/tests/test_emitter.py
+++ b/livekit-rtc/tests/test_emitter.py
@@ -51,16 +51,16 @@ def test_args():
 
     emitter = EventEmitter[EventTypes]()
 
-    args_calls = []
+    calls = []
 
     @emitter.on("whatever")
     def on_whatever(first, second, third):
-        args_calls.append((first, second, third))
+        calls.append((first, second, third))
 
     emitter.emit("whatever", 1, 2, 3)
     emitter.emit("whatever", 1, 2, 3, 4, 5)  # only 3 arguments will be passed
 
-    assert args_calls == [(1, 2, 3), (1, 2, 3)]
+    assert calls == [(1, 2, 3), (1, 2, 3)]
 
     with pytest.raises(TypeError):
         emitter.emit("whatever", 1, 2)
@@ -71,16 +71,16 @@ def test_varargs():
 
     emitter = EventEmitter[EventTypes]()
 
-    varargs_calls = []
+    calls = []
 
     @emitter.on("whatever")
     def on_whatever_varargs(*args):
-        varargs_calls.append(args)
+        calls.append(args)
 
     emitter.emit("whatever", 1, 2, 3, 4, 5)
     emitter.emit("whatever", 1, 2)
 
-    assert varargs_calls == [(1, 2, 3, 4, 5), (1, 2)]
+    assert calls == [(1, 2, 3, 4, 5), (1, 2)]
 
 
 def test_throw():


### PR DESCRIPTION
Some reasonable feedback arrived in community that it's confusing that you can't use async handlers for events in this SDK.  

I looked at the complexity of supporting async handlers and it seems like the largest barrier would be how to await them?  Either the `.emit()` method would need to become async and await them directly, which sounds wrong as you wouldn't expect `.emit()` to block on long-running applications, or you'd need to create tasks to run them asynchronously but then you have the question of where to collect the tasks and how to cancel them or cleanup.

I think it's reasonable to pass this onto the end-developer to collect their own async tasks but we can make it easier to discover this and harder to write subtle bugs. Raising an error with an explanation and workaround suggestion if you pass an async callback seems like a good start.