### PR TITLE
Add support for datastream based chat

### DIFF
--- a/livekit-rtc/livekit/rtc/chat.py
+++ b/livekit-rtc/livekit/rtc/chat.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 import json


### PR DESCRIPTION
This should be backwards compatible with the previous way we handled chat messages. 
Adds the `ignoreLegacy` flag to outgoing legacy messages and ignores incoming dp with the `ignoreLegacy` flag so that we don't double-emit during