### PR TITLE
Add auto chunking for text stream writer

### DIFF
--- a/livekit-rtc/livekit/rtc/__init__.py
+++ b/livekit-rtc/livekit/rtc/__init__.py
@@ -81,7 +81,6 @@ from .rpc import RpcError, RpcInvocationData
 from .synchronizer import AVSynchronizer
 from .data_stream import (
     TextStreamInfo,
-    TextStreamUpdate,
     ByteStreamInfo,
     TextStreamReader,
     TextStreamWriter,
@@ -155,7 +154,6 @@ __all__ = [
     "EventEmitter",
     "combine_audio_frames",
     "AVSynchronizer",
-    "TextStreamUpdate",
     "TextStreamInfo",
     "ByteStreamInfo",
     "TextStreamReader",

--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -47,14 +47,6 @@ class BaseStreamInfo:
 @dataclass
 class TextStreamInfo(BaseStreamInfo):
     attachments: List[str]
-    pass
-
-
-@dataclass
-class TextStreamUpdate:
-    current: str
-    index: int
-    collected: str
 
 
 class TextStreamReader:
@@ -81,22 +73,15 @@ class TextStreamReader:
     async def _on_stream_close(self, trailer: proto_DataStream.Trailer):
         await self._queue.put(None)
 
-    def __aiter__(self) -> AsyncIterator[TextStreamUpdate]:
+    def __aiter__(self) -> AsyncIterator[str]:
         return self
 
-    async def __anext__(self) -> TextStreamUpdate:
+    async def __anext__(self) -> str:
         item = await self._queue.get()
         if item is None:
             raise StopAsyncIteration
         decodedStr = item.content.decode()
-
-        self._chunks[item.chunk_index] = item
-        chunk_list = list(self._chunks.values())
-        chunk_list.sort(key=lambda chunk: chunk.chunk_index)
-        collected: str = "".join(map(lambda chunk: chunk.content.decode(), chunk_list))
-        return TextStreamUpdate(
-            current=decodedStr, index=item.chunk_index, collected=collected
-        )
+        return decodedStr
 
     @property
     def info(self) -> TextStreamInfo:
@@ -104,8 +89,8 @@ class TextStreamReader:
 
     async def read_all(self) -> str:
         final_string = ""
-        async for update in self:
-            final_string = update.collected
+        async for chunk in self:
+            final_string += chunk
         return final_string
 
 

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -34,7 +34,7 @@ from ._proto.room_pb2 import (
 from ._proto.track_pb2 import (
     ParticipantTrackPermission,
 )
-from ._utils import BroadcastQueue, split_utf8
+from ._utils import BroadcastQueue
 from .track import LocalTrack
 from .track_publication import (
     LocalTrackPublication,
@@ -623,8 +623,7 @@ class LocalParticipant(Participant):
             total_size=total_size,
         )
 
-        for chunk in split_utf8(text, STREAM_CHUNK_SIZE):
-            await writer.write(chunk)
+        await writer.write(text)
         await writer.aclose()
 
         return writer.info


### PR DESCRIPTION
- removes mid-stream chunk overrides
- this allows for `writer.write(text)` to perform auto chunking, mirroring the same behaviour as on byte streams
- also allows for send_text to be a thin auto-closing wrapper over stream_text
- allows for `text_reader` to be a simple async iterable of type `str` instead of the `TextStreamUpdate` data class (again improved consistency with how byte stream reader works)

