### PR TITLE
Add stream_id and sender_identity to stream_text params

### DIFF
--- a/livekit-rtc/livekit/rtc/_utils.py
+++ b/livekit-rtc/livekit/rtc/_utils.py
@@ -17,7 +17,7 @@ import logging
 from collections import deque
 import ctypes
 import random
-from typing import Callable, Generic, List, TypeVar
+from typing import Callable, Generator, Generic, List, TypeVar
 
 logger = logging.getLogger("livekit")
 
@@ -133,12 +133,13 @@ def generate_random_base62(length=12):
 
 
 # adapted from https://stackoverflow.com/a/6043797
-def split_utf8(s: str, n: int):
+def split_utf8(s: str, n: int) -> Generator[bytes, None, None]:
     """Split UTF-8 s into chunks of maximum length n."""
-    while len(s) > n:
+    encoded = s.encode()
+    while len(encoded) > n:
         k = n
-        while (ord(s[k]) & 0xC0) == 0x80:
+        while (encoded[k] & 0xC0) == 0x80:
             k -= 1
-        yield s[:k]
-        s = s[k:]
-    yield s
+        yield encoded[:k]
+        encoded = encoded[k:]
+    yield encoded

--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -281,7 +281,6 @@ class TextStreamWriter(BaseStreamWriter):
     async def write(self, text: str):
         async with self._write_lock:
             for chunk in split_utf8(text, STREAM_CHUNK_SIZE):
-                logger.info("Sending chunk: %s", chunk)
                 content = chunk.encode()
                 chunk_index = self._next_chunk_index
                 self._next_chunk_index += 1

--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import uuid
 import datetime
 from collections.abc import Callable
@@ -33,8 +32,6 @@ if TYPE_CHECKING:
     from .participant import LocalParticipant
 
 STREAM_CHUNK_SIZE = 15_000
-
-logger = logging.getLogger("livekit")
 
 
 @dataclass
@@ -70,7 +67,6 @@ class TextStreamReader:
         self._queue: asyncio.Queue[proto_DataStream.Chunk | None] = asyncio.Queue()
 
     async def _on_chunk_update(self, chunk: proto_DataStream.Chunk):
-        logger.info("Received text chunk: %s", chunk.content)
         await self._queue.put(chunk)
 
     async def _on_stream_close(self, trailer: proto_DataStream.Trailer):

--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -64,7 +64,6 @@ class TextStreamReader:
             attachments=list(header.text_header.attached_stream_ids),
         )
         self._queue: asyncio.Queue[proto_DataStream.Chunk | None] = asyncio.Queue()
-        self._chunks: Dict[int, proto_DataStream.Chunk] = {}
 
     async def _on_chunk_update(self, chunk: proto_DataStream.Chunk):
         await self._queue.put(chunk)

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -585,8 +585,10 @@ class LocalParticipant(Participant):
         destination_identities: Optional[List[str]] = None,
         topic: str = "",
         attributes: Optional[Dict[str, str]] = None,
+        stream_id: str | None = None,
         reply_to_id: str | None = None,
         total_size: int | None = None,
+        sender_identity: str | None = None,
     ) -> TextStreamWriter:
         """
         Returns a TextStreamWriter that allows to write individual chunks of text to a text stream.
@@ -599,6 +601,8 @@ class LocalParticipant(Participant):
             reply_to_id=reply_to_id,
             destination_identities=destination_identities,
             total_size=total_size,
+            stream_id=stream_id,
+            sender_identity=sender_identity,
         )
 
         await writer._send_header()


### PR DESCRIPTION
`stream_id` is required for TTS to be able to override previously sent messages with the same stream_id

`sender_identity` allows an agent to override the sending participant. Main usecase is also transcriptions.