### PR TITLE
Text/byte stream handling bug, documentation issues

### DIFF
--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -754,7 +754,7 @@ class Room(EventEmitter[EventTypes]):
             text_reader = TextStreamReader(header)
             self._text_stream_readers[header.stream_id] = text_reader
             task = asyncio.create_task(
-                text_stream_handler(text_reader, participant_identity, self)
+                text_stream_handler(text_reader, participant_identity)
             )
             self._data_stream_tasks.add(task)
             task.add_done_callback(self._data_stream_tasks.discard)


### PR DESCRIPTION
Fix for RuntimeWarning: coroutine 'RoomManager.handle_text_stream' was never awaited This occurs when a message is received from a text (or byte) stream.

As shown in the documentation here, https://docs.livekit.io/home/client/data/text-streams/ a stream should register a handle like this:

 ```
room.register_text_stream_handler(
    "my-topic",
    handle_text_stream
)
```

But this results in the error above. 

Furthmore, some documentation from the [text-streams page above](https://docs.livekit.io/home/client/data/text-streams) is wrong.
1. handling streams > python >         `f'  ID: {info.id}\n' ` should read        ` f'  ID: {info.stream_id}\n' `
2. handling streams > javascript >  `room.registerTextStreamHandler('my-topic', (reader, participantInfo) => { `should read  `room.registerTextStreamHandler('my-topic', async (reader, participantInfo) => {`
