### PR TITLE
Add `off_all` method to `EventEmitter`

### DIFF
--- a/livekit-rtc/livekit/rtc/event_emitter.py
+++ b/livekit-rtc/livekit/rtc/event_emitter.py
@@ -198,3 +198,7 @@ class EventEmitter(Generic[T_contra]):
         """
         if event in self._events:
             self._events[event].discard(callback)
+
+    def off_all(self):
+        """Unregister all callbacks from all events."""
+        self._events.clear()


### PR DESCRIPTION
We want to support removing all events and their associated callbacks.