### PR TITLE
Fix: Start ByteStreamWriter chunk index at 0 #430

### DIFF
--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -340,13 +340,13 @@ class ByteStreamWriter(BaseStreamWriter):
             ]
 
             for chunk in chunked_data:
-                self._next_chunk_index += 1
                 chunk_msg = proto_DataStream.Chunk(
                     stream_id=self._header.stream_id,
                     chunk_index=self._next_chunk_index,
                     content=chunk,
                 )
                 await self._send_chunk(chunk_msg)
+                self._next_chunk_index += 1
 
     @property
     def info(self) -> ByteStreamInfo:


### PR DESCRIPTION
This PR fixes a bug in `ByteStreamWriter` where the first data chunk was incorrectly sent with **_chunk_index = 1_** instead of the expected 0.

**Problem:**
As described in Issue #430 , the `_next_chunk_index` was incremented before being used in the write method, causing incompatibility with clients (like the Unity SDK's ByteStreamReader) that expect stream chunk indices to start at 0. 
This differs from the behavior of `TextStreamWriter`, which correctly starts at index 0.

**Changes:**
The ByteStreamWriter.write method has been modified to:
Use the current value of `_next_chunk_index` (which starts at 0 in `BaseStreamWriter`) for the chunk_index.
Increment `_next_chunk_index` after the chunk message has been sent via `_send_chunk`.
This aligns the behavior with `TextStreamWriter` and ensures correct 0-based indexing for byte streams, resolving client-side errors related to chunk index expectation.