### PR TITLE
Fix AVSynchronizer Bug when video frames are significantly behind schedule

### DIFF
--- a/livekit-rtc/livekit/rtc/synchronizer.py
+++ b/livekit-rtc/livekit/rtc/synchronizer.py
@@ -175,7 +175,6 @@ class _FPSController:
             # check if significantly behind schedule
             if -sleep_time > self._max_delay_tolerance_secs:
                 logger.warning(f"Frame capture was behind schedule for {-sleep_time * 1000:.2f} ms")
-                self._next_frame_time = time.perf_counter()
 
     def after_process(self) -> None:
         """Update timing information after processing a frame."""


### PR DESCRIPTION
When video frames are significantly behind schedule (i.e. when the check in line 176 passes), self._next_frame_time should not be handled any differently. 

By setting self._next_frame_time = time.perf_counter(), we don't allow for frames to be played at a faster frame-rate to be able to catch up. This is especially a problem whenever the video falls significantly behind the audio.

Removing this line means that until self.next_frame_time catches up to current_time (defined in line 164), we don't wait before playing available video frames. This allows us to have some semblance of ground truth w.r.t. video frames and allows us to "catch up" to where the video should be if we fall significantly behind schedule.