### PR TITLE
Implement task_done calls after queue.wait_for

### DIFF
--- a/livekit-rtc/livekit/rtc/audio_source.py
+++ b/livekit-rtc/livekit/rtc/audio_source.py
@@ -142,6 +142,7 @@ class AudioSource:
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.capture_audio_frame.async_id == resp.capture_audio_frame.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 

--- a/livekit-rtc/livekit/rtc/data_stream.py
+++ b/livekit-rtc/livekit/rtc/data_stream.py
@@ -182,6 +182,7 @@ class BaseStreamWriter:
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.send_stream_header.async_id == resp.send_stream_header.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -206,6 +207,7 @@ class BaseStreamWriter:
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.send_stream_chunk.async_id == resp.send_stream_chunk.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -227,6 +229,7 @@ class BaseStreamWriter:
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.send_stream_trailer.async_id == resp.send_stream_trailer.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -210,6 +210,7 @@ class LocalParticipant(Participant):
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.publish_data.async_id == resp.publish_data.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -238,6 +239,7 @@ class LocalParticipant(Participant):
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.publish_sip_dtmf.async_id == resp.publish_sip_dtmf.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -278,6 +280,7 @@ class LocalParticipant(Participant):
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.publish_transcription.async_id == resp.publish_transcription.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -321,6 +324,7 @@ class LocalParticipant(Participant):
             cb = await queue.wait_for(
                 lambda e: (e.perform_rpc.async_id == resp.perform_rpc.async_id)
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -494,6 +498,7 @@ class LocalParticipant(Participant):
             await queue.wait_for(
                 lambda e: e.set_local_metadata.async_id == resp.set_local_metadata.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -516,6 +521,7 @@ class LocalParticipant(Participant):
             await queue.wait_for(
                 lambda e: e.set_local_name.async_id == resp.set_local_name.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -546,6 +552,7 @@ class LocalParticipant(Participant):
             await queue.wait_for(
                 lambda e: e.set_local_attributes.async_id == resp.set_local_attributes.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -386,6 +386,7 @@ class Room(EventEmitter[EventTypes]):
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.connect.async_id == resp.connect.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -428,6 +429,7 @@ class Room(EventEmitter[EventTypes]):
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.get_session_stats.async_id == resp.get_session_stats.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 
@@ -475,6 +477,7 @@ class Room(EventEmitter[EventTypes]):
         try:
             resp = FfiClient.instance.request(req)
             await queue.wait_for(lambda e: e.disconnect.async_id == resp.disconnect.async_id)
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 

--- a/livekit-rtc/livekit/rtc/track.py
+++ b/livekit-rtc/livekit/rtc/track.py
@@ -58,6 +58,7 @@ class Track:
             cb: proto_ffi.FfiEvent = await queue.wait_for(
                 lambda e: e.get_stats.async_id == resp.get_stats.async_id
             )
+            queue.task_done()
         finally:
             FfiClient.instance.queue.unsubscribe(queue)
 


### PR DESCRIPTION
- I added task done after queue.wait_for finish to ensure proper task management and resource cleanup. I face the issue with memory leak for my service, this is first point I see that current library missing to mark event done.
- I re-arrange order operations in AudioStream init method because of potential of missing FfiHandle before run loop started