### PR TITLE
[fix] trunk_ids Assignment Error in SIPDispatchRuleUpdate

### DIFF
--- a/livekit-api/livekit/api/sip_service.py
+++ b/livekit-api/livekit/api/sip_service.py
@@ -330,10 +330,12 @@ class SipService(Service):
         Only provided fields will be updated.
         """
         update = SIPDispatchRuleUpdate(
-            name=name, metadata=metadata, rule=rule, attributes=attributes
+            name=name, 
+            metadata=metadata, 
+            rule=rule, 
+            attributes=attributes,
+            trunk_ids=ListUpdate(set=trunk_ids) if trunk_ids else None,
         )
-        if trunk_ids is not None:
-            update.trunk_ids = ListUpdate(set=trunk_ids)
         return await self._client.request(
             SVC,
             "UpdateSIPDispatchRule",


### PR DESCRIPTION
### Overview
LiveKit's SIPDispatchRuleUpdate is a protobuf message where fields like `trunk_ids` must be set during initialization.

### Problem
Attempting to assign `trunk_ids` after instantiation raised the following runtime error:

  AttributeError: Assignment not allowed to message, map, or repeated field "trunk_ids" in protocol message object.

This is due to protobuf’s restriction against direct assignment to message or repeated fields after construction.

### Fix
Set `trunk_ids` during SIPDispatchRuleUpdate construction using `ListUpdate(set=...)`, ensuring proper initialization and serialization by the protobuf engine.
