### PR TITLE
Adding the inference grant

### DIFF
--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -75,10 +75,12 @@ class SIPGrants:
     # make outbound calls
     call: bool = False
 
+
 @dataclasses.dataclass
 class InferenceGrants:
     # perform inference
     perform: bool = False
+
 
 @dataclasses.dataclass
 class Claims:
@@ -140,7 +142,7 @@ class AccessToken:
     def with_sip_grants(self, grants: SIPGrants) -> "AccessToken":
         self.claims.sip = grants
         return self
-    
+
     def with_inference_grants(self, grants: InferenceGrants) -> "AccessToken":
         self.claims.inference = grants
         return self
@@ -236,7 +238,9 @@ class TokenVerifier:
 
         inference_dict = claims.get("inference", dict())
         inference_dict = {camel_to_snake(k): v for k, v in inference_dict.items()}
-        inference_dict = {k: v for k, v in inference_dict.items() if k in InferenceGrants.__dataclass_fields__}
+        inference_dict = {
+            k: v for k, v in inference_dict.items() if k in InferenceGrants.__dataclass_fields__
+        }
         inference = InferenceGrants(**inference_dict)
 
         grant_claims = Claims(

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -75,6 +75,10 @@ class SIPGrants:
     # make outbound calls
     call: bool = False
 
+@dataclasses.dataclass
+class InferenceGrants:
+    # perform inference
+    perform: bool = False
 
 @dataclasses.dataclass
 class Claims:
@@ -84,6 +88,7 @@ class Claims:
     metadata: str = ""
     video: Optional[VideoGrants] = None
     sip: Optional[SIPGrants] = None
+    inference: Optional[InferenceGrants] = None
     attributes: Optional[dict[str, str]] = None
     sha256: Optional[str] = None
     room_preset: Optional[str] = None
@@ -134,6 +139,10 @@ class AccessToken:
 
     def with_sip_grants(self, grants: SIPGrants) -> "AccessToken":
         self.claims.sip = grants
+        return self
+    
+    def with_inference_grants(self, grants: InferenceGrants) -> "AccessToken":
+        self.claims.inference = grants
         return self
 
     def with_identity(self, identity: str) -> "AccessToken":
@@ -225,11 +234,17 @@ class TokenVerifier:
         sip_dict = {k: v for k, v in sip_dict.items() if k in SIPGrants.__dataclass_fields__}
         sip = SIPGrants(**sip_dict)
 
+        inference_dict = claims.get("inference", dict())
+        inference_dict = {camel_to_snake(k): v for k, v in inference_dict.items()}
+        inference_dict = {k: v for k, v in inference_dict.items() if k in InferenceGrants.__dataclass_fields__}
+        inference = InferenceGrants(**inference_dict)
+
         grant_claims = Claims(
             identity=claims.get("sub", ""),
             name=claims.get("name", ""),
             video=video,
             sip=sip,
+            inference=inference,
             attributes=claims.get("attributes", {}),
             metadata=claims.get("metadata", ""),
             sha256=claims.get("sha256", ""),


### PR DESCRIPTION
The `InferenceGrant` is required to perform LLM inference in the backend. This will be used by the agents SDK.