### PR TITLE
Add support for datachannel encryption

### DIFF
--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -487,7 +487,9 @@ class Room(EventEmitter[EventTypes]):
 
         self._ffi_handle = FfiHandle(cb.connect.result.room.handle.id)
 
-        self._e2ee_manager = E2EEManager(self._ffi_handle.handle, options.e2ee)
+        self._e2ee_manager = E2EEManager(
+            self._ffi_handle.handle, options.encryption or options.e2ee
+        )
 
         self._info = cb.connect.result.room.info
         self._connection_state = ConnectionState.CONN_CONNECTED


### PR DESCRIPTION
also exposes participantEncryptionChanged event and updates rust sdks (currently not to a new FFI build, which needs to get fixed)