### PR TITLE
fix crash when zero byte data is pushed into resampler

### DIFF
--- a/livekit-rtc/livekit/rtc/audio_resampler.py
+++ b/livekit-rtc/livekit/rtc/audio_resampler.py
@@ -94,6 +94,8 @@ class AudioResampler:
             Exception: If there is an error during resampling.
         """
         bdata = data if isinstance(data, bytearray) else data.data.cast("b")
+        if not bdata:
+            return []
 
         req = proto_ffi.FfiRequest()
         req.push_sox_resampler.resampler_handle = self._ffi_handle.handle


### PR DESCRIPTION
when a 0 byte array is pushed into AudioResampler, it raises:

```
ValueError: Buffer size too small (0 instead of at least 1 bytes)
```