### PR TITLE
ci: remove release label from publish PR creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
             --head "$branch" \
             --title "${INPUT_PACKAGE} v${VERSION}" \
             --body "Merging this PR will publish **${INPUT_PACKAGE}** v${VERSION} to PyPI." \
-            --label "release"
+
 
   # ── Step 2: Publish on merge ──────────────────────────────────
   detect:


### PR DESCRIPTION
The `release` label doesn't exist in this repo, causing the PR creation step to fail.