### PR TITLE
fix(rtc): avoid KeyError in local_track_unpublished handler during teardown

### DIFF
--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -784,6 +784,13 @@ class LocalParticipant(Participant):
         Raises:
             UnpublishTrackError: If there is an error in unpublishing the track.
         """
+        # Capture the publication before the FFI round-trip. The
+        # local_track_unpublished room event races this async response and may
+        # remove it from _track_publications first; holding our own reference
+        # guarantees the track is cleared once unpublish completes, regardless
+        # of which path removes the publication from the dict.
+        publication = self._track_publications.get(track_sid)
+
         req = proto_ffi.FfiRequest()
         req.unpublish_track.local_participant_handle = self._ffi_handle.handle
         req.unpublish_track.track_sid = track_sid
@@ -799,10 +806,9 @@ class LocalParticipant(Participant):
             if cb.unpublish_track.error:
                 raise UnpublishTrackError(cb.unpublish_track.error)
 
-            # The local_track_unpublished room event may have already removed
-            # this publication from the dict (the FFI event and this async
-            # response race during teardown), so pop defensively.
-            publication = self._track_publications.pop(track_sid, None)
+            # Remove defensively: the room-event handler may already have done
+            # so when it processed local_track_unpublished first.
+            self._track_publications.pop(track_sid, None)
             if publication is not None:
                 publication._track = None
             queue.task_done()

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -799,8 +799,12 @@ class LocalParticipant(Participant):
             if cb.unpublish_track.error:
                 raise UnpublishTrackError(cb.unpublish_track.error)
 
-            publication = self._track_publications.pop(track_sid)
-            publication._track = None
+            # The local_track_unpublished room event may have already removed
+            # this publication from the dict (the FFI event and this async
+            # response race during teardown), so pop defensively.
+            publication = self._track_publications.pop(track_sid, None)
+            if publication is not None:
+                publication._track = None
             queue.task_done()
         finally:
             self._room_queue.unsubscribe(queue)

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -735,9 +735,21 @@ class Room(EventEmitter[EventTypes]):
             ltrack = lpublication.track
             self.emit("local_track_published", lpublication, ltrack)
         elif which == "local_track_unpublished":
+            # During teardown the publication may already have been removed
+            # from the participant's dict by LocalParticipant.unpublish_track
+            # (or by a previously processed event), so the SID can be gone by
+            # the time this event is dispatched. Pop defensively and skip the
+            # emit when it is no longer tracked, mirroring the remote
+            # track_unpublished and local_track_republished handlers, instead
+            # of raising a KeyError that _listen_task logs as an error.
             sid = event.local_track_unpublished.publication_sid
-            lpublication = self.local_participant.track_publications[sid]
-            self.emit("local_track_unpublished", lpublication)
+            lpublication = self.local_participant._track_publications.pop(sid, None)
+            if lpublication is not None:
+                self.emit("local_track_unpublished", lpublication)
+            else:
+                logging.debug(
+                    "local_track_unpublished for untracked publication sid %s", sid
+                )
         elif which == "local_track_republished":
             # The SDK auto-republished a local track during a full
             # reconnect: the underlying Track (and its bound source) is

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -737,19 +737,18 @@ class Room(EventEmitter[EventTypes]):
         elif which == "local_track_unpublished":
             # During teardown the publication may already have been removed
             # from the participant's dict by LocalParticipant.unpublish_track
-            # (or by a previously processed event), so the SID can be gone by
-            # the time this event is dispatched. Pop defensively and skip the
-            # emit when it is no longer tracked, mirroring the remote
-            # track_unpublished and local_track_republished handlers, instead
-            # of raising a KeyError that _listen_task logs as an error.
+            # (the FFI event races that async response), so the SID can be gone
+            # by the time this event is dispatched. Look it up defensively and
+            # skip the emit when it is no longer tracked, mirroring the
+            # local_track_republished and remote track_unpublished handlers,
+            # instead of raising a KeyError that _listen_task logs as an error.
             sid = event.local_track_unpublished.publication_sid
-            lpublication = self.local_participant._track_publications.pop(sid, None)
-            if lpublication is not None:
-                self.emit("local_track_unpublished", lpublication)
+            unpublished = self.local_participant._track_publications.get(sid)
+            if unpublished is not None:
+                del self.local_participant._track_publications[sid]
+                self.emit("local_track_unpublished", unpublished)
             else:
-                logging.debug(
-                    "local_track_unpublished for untracked publication sid %s", sid
-                )
+                logging.debug("local_track_unpublished for untracked publication sid %s", sid)
         elif which == "local_track_republished":
             # The SDK auto-republished a local track during a full
             # reconnect: the underlying Track (and its bound source) is


### PR DESCRIPTION
**Fixes livekit/python-sdks#681** — https://github.com/livekit/python-sdks/issues/681

## Problem

`Room._on_room_event` does an unchecked `self.local_participant.track_publications[sid]` lookup on the `local_track_unpublished` branch (room.py). `LocalParticipant.unpublish_track` removes the publication from `_track_publications` when its FFI async response is processed, and that response races the `local_track_unpublished` room event. When the response is handled first, the SID is already gone by the time the event is dispatched and the handler raises `KeyError`.

`_listen_task` catches it and logs `error running user callback for local_track_unpublished: ...` with a full traceback, so the worker does not crash — but every affected disconnect cleanup produces a spurious ERROR log. In a production agent fleet this fired ~18×/24h on early/`CLIENT_INITIATED` disconnects (~1 in several hundred). The `local_track_unpublished` event is also silently dropped when the race fires.

This is the only `local_track_*` handler that crashes on a missing SID — `track_unpublished` (remote) and `local_track_republished` (#655) already tolerate it.

## Fix

**`room.py` — handler:** pop defensively and only emit when present, mirroring the remote `track_unpublished` and `local_track_republished` handlers (with a `debug` log for the dropped case):

```python
sid = event.local_track_unpublished.publication_sid
lpublication = self.local_participant._track_publications.pop(sid, None)
if lpublication is not None:
    self.emit("local_track_unpublished", lpublication)
else:
    logging.debug("local_track_unpublished for untracked publication sid %s", sid)
```

This also folds removal into the handler, fixing a latent leak where a server-forced unpublish (no `unpublish_track` call) previously left the publication in the dict forever.

**`participant.py` — `unpublish_track`:** make its pop tolerant.

```python
publication = self._track_publications.pop(track_sid, None)
if publication is not None:
    publication._track = None
```

This second change is required, not cosmetic. The KeyError is rare (~1 in several hundred), which means the **common** ordering is the room event being processed *while the SID is still present* — i.e. before `unpublish_track`'s pop. Once the handler itself starts popping, in that common path the old **unchecked** `pop(track_sid)` in `unpublish_track` would raise a *new* `KeyError` on nearly every unpublish. Making it tolerant prevents simply relocating the crash.

## Behavior across both race orderings

- **Event first (common):** handler pops + emits; `unpublish_track` gets `None`, skips — no crash, event still delivered.
- **Async response first (the rare race that was crashing):** `unpublish_track` pops + clears `_track`; handler gets `None`, skips emit — no crash. The event is dropped, but it was crashing (never emitting) before, so this is strictly better.

## Testing

- `ast`-parsed both files; no new lint/type diagnostics.
- The repo has no unit tests around `_on_room_event` (existing tests are e2e and require a live server), so no test was added. Happy to add one with a mocked participant if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
