### PR TITLE
Add missing connection quality field

### DIFF
--- a/livekit-rtc/livekit/rtc/__init__.py
+++ b/livekit-rtc/livekit/rtc/__init__.py
@@ -27,7 +27,6 @@ from ._proto.participant_pb2 import (
     DisconnectReason,
 )
 from ._proto.room_pb2 import (
-    ConnectionQuality,
     ConnectionState,
     ContinualGatheringPolicy,
     DataPacketKind,
@@ -58,6 +57,7 @@ from .e2ee import (
     KeyProviderOptions,
 )
 from .participant import (
+    ConnectionQuality,
     LocalParticipant,
     Participant,
     RemoteParticipant,

--- a/livekit-rtc/livekit/rtc/participant.py
+++ b/livekit-rtc/livekit/rtc/participant.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import ctypes
 import asyncio
 import datetime
+import enum
 import os
 import mimetypes
 import aiofiles
@@ -28,6 +29,9 @@ from ._proto import ffi_pb2 as proto_ffi
 from ._proto import participant_pb2 as proto_participant
 from ._proto.room_pb2 import (
     TrackPublishOptions,
+)
+from ._proto.room_pb2 import (
+    ConnectionQuality as ProtoConnectionQuality,
 )
 from ._proto.room_pb2 import (
     TranscriptionSegment as ProtoTranscriptionSegment,
@@ -89,10 +93,29 @@ class PublishDataTrackError(Exception):
         self.message = message
 
 
+class ConnectionQuality(enum.IntEnum):
+    """Connection quality reported for a participant."""
+
+    QUALITY_UNKNOWN = -1
+    """No connection-quality update has been reported yet (no proto equivalent)."""
+    QUALITY_POOR = ProtoConnectionQuality.QUALITY_POOR
+    QUALITY_GOOD = ProtoConnectionQuality.QUALITY_GOOD
+    QUALITY_EXCELLENT = ProtoConnectionQuality.QUALITY_EXCELLENT
+    QUALITY_LOST = ProtoConnectionQuality.QUALITY_LOST
+
+
+def _connection_quality_from_proto(value: int) -> ConnectionQuality:
+    try:
+        return ConnectionQuality(value)
+    except ValueError:
+        return ConnectionQuality.QUALITY_UNKNOWN
+
+
 class Participant(ABC):
     def __init__(self, owned_info: proto_participant.OwnedParticipant) -> None:
         self._info = owned_info.info
         self._ffi_handle = FfiHandle(owned_info.handle.id)
+        self._connection_quality = ConnectionQuality.QUALITY_UNKNOWN
 
     @property
     @abstractmethod
@@ -151,6 +174,16 @@ class Participant(ABC):
     def permissions(self) -> proto_participant.ParticipantPermission:
         """The participant's permissions within the room."""
         return self._info.permission
+
+    @property
+    def connection_quality(self) -> ConnectionQuality:
+        """The participant's most recently reported connection quality.
+
+        Returns ``ConnectionQuality.QUALITY_UNKNOWN`` until the first
+        connection-quality update is received. Updated automatically whenever a
+        ``connection_quality_changed`` event fires for this participant.
+        """
+        return self._connection_quality
 
     @property
     def disconnect_reason(

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -33,7 +33,12 @@ from ._proto.track_pb2 import TrackKind
 from ._proto.rpc_pb2 import RpcMethodInvocationEvent
 from ._utils import BroadcastQueue
 from .e2ee import E2EEManager, E2EEOptions
-from .participant import LocalParticipant, Participant, RemoteParticipant
+from .participant import (
+    LocalParticipant,
+    Participant,
+    RemoteParticipant,
+    _connection_quality_from_proto,
+)
 from .track import RemoteAudioTrack, RemoteVideoTrack
 from .track_publication import RemoteTrackPublication, TrackPublication
 from .transcription import TranscriptionSegment
@@ -897,12 +902,16 @@ class Room(EventEmitter[EventTypes]):
             )
         elif which == "connection_quality_changed":
             identity = event.connection_quality_changed.participant_identity
-            # TODO: pass participant identity
             participant = self._retrieve_participant(identity)
+            quality = _connection_quality_from_proto(
+                event.connection_quality_changed.quality
+            )
+            if participant:
+                participant._connection_quality = quality
             self.emit(
                 "connection_quality_changed",
                 participant,
-                event.connection_quality_changed.quality,
+                quality,
             )
         elif which == "transcription_received":
             transcription = event.transcription_received

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -903,9 +903,7 @@ class Room(EventEmitter[EventTypes]):
         elif which == "connection_quality_changed":
             identity = event.connection_quality_changed.participant_identity
             participant = self._retrieve_participant(identity)
-            quality = _connection_quality_from_proto(
-                event.connection_quality_changed.quality
-            )
+            quality = _connection_quality_from_proto(event.connection_quality_changed.quality)
             if participant:
                 participant._connection_quality = quality
             self.emit(

--- a/tests/rtc/test_connection_quality.py
+++ b/tests/rtc/test_connection_quality.py
@@ -1,0 +1,29 @@
+"""Unit tests for the local ConnectionQuality enum and the participant property."""
+
+from livekit import rtc
+from livekit.rtc._proto import participant_pb2 as proto_participant
+from livekit.rtc._proto import room_pb2 as proto_room
+from livekit.rtc.participant import _connection_quality_from_proto
+
+
+def test_enum_values_align_with_proto() -> None:
+    CQ = rtc.ConnectionQuality
+    assert CQ.QUALITY_UNKNOWN == -1
+    assert CQ.QUALITY_POOR == proto_room.ConnectionQuality.QUALITY_POOR
+    assert CQ.QUALITY_GOOD == proto_room.ConnectionQuality.QUALITY_GOOD
+    assert CQ.QUALITY_EXCELLENT == proto_room.ConnectionQuality.QUALITY_EXCELLENT
+    assert CQ.QUALITY_LOST == proto_room.ConnectionQuality.QUALITY_LOST
+    # backward compat: still int-comparable like the old proto enum export
+    assert CQ.QUALITY_GOOD == 1
+
+
+def test_from_proto_mapping() -> None:
+    assert _connection_quality_from_proto(1) is rtc.ConnectionQuality.QUALITY_GOOD
+    assert _connection_quality_from_proto(99) is rtc.ConnectionQuality.QUALITY_UNKNOWN
+
+
+def test_participant_default_quality_is_unknown() -> None:
+    owned = proto_participant.OwnedParticipant()
+    owned.info.identity = "test"
+    participant = rtc.RemoteParticipant(owned)
+    assert participant.connection_quality is rtc.ConnectionQuality.QUALITY_UNKNOWN


### PR DESCRIPTION
Most other client sdks (checked [web](https://github.com/livekit/client-sdk-js/blob/59d29ab6367894be72435ead90e33e5f79e323db/src/room/participant/Participant.ts#L210), [swift](https://github.com/livekit/client-sdk-swift/blob/1ac55b4b61f8c26657d4d78cda16d95669a95ebe/Sources/LiveKit/Participant/Participant.swift#L46), and [android](https://github.com/livekit/client-sdk-android/blob/2f40d86f6b6a5535d2299767fddcf69d219f1174/livekit-android-sdk/src/main/java/io/livekit/android/room/participant/Participant.kt#L246)) support a `participant.connectionQuality` type field in addition to a "participant connection quality changed" event. However, the python sdk seems to be missing it, and only exposes this over an event. Fix this so that the sdks are more consistent with each other.

Note that I have opted to introduce a shadowed `ConnectionQuality` custom enum rather than return the protobuf version directly here (like how it used to work). This should be fully backwards compatible and means that the new `participant.connection_quality` field can be `QUALITY_UNKNOWN` until the first connection quality event is received, matching behavior in other sdks.