### PR TITLE
fix: unsubscribe FFI queue when the room listen task ends

### DIFF
--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -557,6 +557,14 @@ class Room(EventEmitter[EventTypes]):
         # start listening to room events
         self._task = self._loop.create_task(self._listen_task())
 
+        # unsubscribe from the FFI queue once the listen task ends.
+        # disconnect() unsubscribes too, but it early-returns when the
+        # room is already disconnected (e.g. removed remotely).
+        ffi_queue = self._ffi_queue
+        self._task.add_done_callback(
+            lambda _: FfiClient.instance.queue.unsubscribe(ffi_queue)
+        )
+
         # Unblock the FFI server once this SDK is ready to receive room events.
         ready_req = proto_ffi.FfiRequest()
         ready_req.ready_for_room_event.room_handle = self._ffi_handle.handle

--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -561,9 +561,7 @@ class Room(EventEmitter[EventTypes]):
         # disconnect() unsubscribes too, but it early-returns when the
         # room is already disconnected (e.g. removed remotely).
         ffi_queue = self._ffi_queue
-        self._task.add_done_callback(
-            lambda _: FfiClient.instance.queue.unsubscribe(ffi_queue)
-        )
+        self._task.add_done_callback(lambda _: FfiClient.instance.queue.unsubscribe(ffi_queue))
 
         # Unblock the FFI server once this SDK is ready to receive room events.
         ready_req = proto_ffi.FfiRequest()


### PR DESCRIPTION
When a room is disconnected remotely (e.g. the participant is removed), `Room.disconnect()` early-returns on `not isconnected()` and never unsubscribes the room's FFI event queue. The FFI receive thread keeps posting events to it, and once the event loop closes it logs `error putting to queue: Event loop is closed`.

Unsubscribe the FFI queue in a done callback on the listen task, so the subscription's lifetime matches its only consumer (`_listen_task`) regardless of how it ends — EOS, error, or cancellation. `unsubscribe` is idempotent, so the existing calls in `disconnect()` and `__del__` stay harmless.