### PR TITLE
docs: add deployment field documentation for agent dispatch

### DIFF
--- a/examples/agent_dispatch.py
+++ b/examples/agent_dispatch.py
@@ -19,23 +19,15 @@ Leave empty to target the production deployment.
 async def create_explicit_dispatch():
     lkapi = api.LiveKitAPI()
 
-    # Create a dispatch targeting the production deployment (default)
     dispatch = await lkapi.agent_dispatch.create_dispatch(
         api.CreateAgentDispatchRequest(
-            agent_name=agent_name, room=room_name, metadata="my_metadata"
+            agent_name=agent_name,
+            room=room_name,
+            metadata="my_metadata",
+            # deployment="staging",  # Optional: target a specific deployment
         )
     )
     print("created dispatch", dispatch)
-
-    # Create a dispatch targeting a specific deployment (e.g., "staging")
-    # dispatch = await lkapi.agent_dispatch.create_dispatch(
-    #     api.CreateAgentDispatchRequest(
-    #         agent_name=agent_name,
-    #         room=room_name,
-    #         metadata="my_metadata",
-    #         deployment="staging",
-    #     )
-    # )
 
     dispatches = await lkapi.agent_dispatch.list_dispatch(room_name=room_name)
     print(f"there are {len(dispatches)} dispatches in {room_name}")

--- a/examples/agent_dispatch.py
+++ b/examples/agent_dispatch.py
@@ -5,23 +5,37 @@ room_name = "my-room"
 agent_name = "test-agent"
 
 """
-This example demonstrates how to have an agent join a room 
-without using the automatic dispatch. In order to use this 
-feature, you must have an agent running with `agent_name` set 
-when defining your WorkerOptions. A dispatch requests the 
+This example demonstrates how to have an agent join a room
+without using the automatic dispatch. In order to use this
+feature, you must have an agent running with `agent_name` set
+when defining your WorkerOptions. A dispatch requests the
 agent to enter a specific room with optional metadata.
+
+You can also specify a `deployment` to target a specific agent deployment.
+Leave empty to target the production deployment.
 """
 
 
 async def create_explicit_dispatch():
     lkapi = api.LiveKitAPI()
 
+    # Create a dispatch targeting the production deployment (default)
     dispatch = await lkapi.agent_dispatch.create_dispatch(
         api.CreateAgentDispatchRequest(
             agent_name=agent_name, room=room_name, metadata="my_metadata"
         )
     )
     print("created dispatch", dispatch)
+
+    # Create a dispatch targeting a specific deployment (e.g., "staging")
+    # dispatch = await lkapi.agent_dispatch.create_dispatch(
+    #     api.CreateAgentDispatchRequest(
+    #         agent_name=agent_name,
+    #         room=room_name,
+    #         metadata="my_metadata",
+    #         deployment="staging",
+    #     )
+    # )
 
     dispatches = await lkapi.agent_dispatch.list_dispatch(room_name=room_name)
     print(f"there are {len(dispatches)} dispatches in {room_name}")
@@ -33,6 +47,9 @@ When agent name is set, the agent will no longer be automatically dispatched
 to new rooms. If you want that agent to be dispatched to a new room as soon as
 the participant connects, you can set the RoomConfiguration with the agent
 definition in the access token.
+
+You can also specify a `deployment` in the RoomAgentDispatch to target a specific
+agent deployment. Leave empty to target the production deployment.
 """
 
 
@@ -43,7 +60,13 @@ async def create_token_with_agent_dispatch() -> str:
         .with_grants(api.VideoGrants(room_join=True, room=room_name))
         .with_room_config(
             api.RoomConfiguration(
-                agents=[api.RoomAgentDispatch(agent_name="test-agent", metadata="my_metadata")],
+                agents=[
+                    api.RoomAgentDispatch(
+                        agent_name="test-agent",
+                        metadata="my_metadata",
+                        # deployment="staging",  # Optional: target a specific deployment
+                    )
+                ],
             ),
         )
         .to_jwt()

--- a/livekit-api/livekit/api/agent_dispatch_service.py
+++ b/livekit-api/livekit/api/agent_dispatch_service.py
@@ -35,7 +35,9 @@ class AgentDispatchService(Service):
         To use explicit dispatch, your agent must be registered with an `agentName`.
 
         Args:
-            req (CreateAgentDispatchRequest): Request containing dispatch creation parameters
+            req (CreateAgentDispatchRequest): Request containing dispatch creation parameters.
+                The request can include an optional `deployment` field to target a specific
+                deployment. Leave empty to target the production deployment.
 
         Returns:
             AgentDispatch: The created agent dispatch object


### PR DESCRIPTION
## Summary
- Update docstrings to document the `deployment` field in `create_dispatch`
- Update examples to show how to use the `deployment` field for both explicit dispatch and token-based dispatch

The `deployment` field allows targeting a specific agent deployment (e.g., "staging"). Leave empty to target the production deployment.

Related PRs:
- node-sdks: https://github.com/livekit/node-sdks/pull/675
- client-sdk-js: https://github.com/livekit/client-sdk-js/pull/1971

## Test plan

### Unit Tests
```bash
cd /path/to/python-sdks
pytest tests/api/test_access_token.py -v
```

### Manual Verification

**1. Verify deployment field is sent in request:**
```python
from livekit import api

async def test_deployment():
    lkapi = api.LiveKitAPI()
    
    # Create dispatch with deployment
    dispatch = await lkapi.agent_dispatch.create_dispatch(
        api.CreateAgentDispatchRequest(
            agent_name="my-agent",
            room="test-room",
            deployment="staging"
        )
    )
    
    # Verify response contains deployment
    print(f"Dispatch ID: {dispatch.id}")
    print(f"Deployment: {dispatch.deployment}")  # Should print "staging"
    
    await lkapi.aclose()
```

**2. Verify via list_dispatch:**
```python
dispatches = await lkapi.agent_dispatch.list_dispatch(room_name="test-room")
for d in dispatches:
    print(f"Dispatch {d.id}: deployment={d.deployment}")
```

**3. Verify server rejects invalid deployment:**
```python
# Should fail - deployment exceeds 63 chars
try:
    await lkapi.agent_dispatch.create_dispatch(
        api.CreateAgentDispatchRequest(
            agent_name="my-agent",
            room="test-room",
            deployment="a" * 100
        )
    )
except Exception as e:
    print(f"Server correctly rejected: {e}")
```

**4. Verify token-based dispatch includes deployment:**
```python
import jwt

token = (
    api.AccessToken()
    .with_identity("test-user")
    .with_grants(api.VideoGrants(room_join=True, room="test-room"))
    .with_room_config(
        api.RoomConfiguration(
            agents=[api.RoomAgentDispatch(
                agent_name="my-agent",
                deployment="staging"
            )]
        )
    )
    .to_jwt()
)

# Decode and verify
payload = jwt.decode(token, options={"verify_signature": False})
agents = payload.get("roomConfig", {}).get("agents", [])
print(f"Agents in token: {agents}")  # Should show deployment field
```

### End-to-End Verification
1. Register an agent worker with `deployment="staging"`
2. Create a dispatch targeting `deployment="staging"`
3. Verify only the staging agent receives the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)