### PR TITLE
Start AudioStream _run task after the FFI handle is assigned

### DIFF
--- a/livekit-rtc/livekit/rtc/audio_stream.py
+++ b/livekit-rtc/livekit/rtc/audio_stream.py
@@ -125,9 +125,6 @@ class AudioStream:
             self._processor = noise_cancellation
             self._processor_auto_close = auto_close_noise_cancellation
 
-        self._task = self._loop.create_task(self._run())
-        self._task.add_done_callback(task_done_logger)
-
         stream: Any = None
         if "participant" in kwargs:
             stream = self._create_owned_stream_from_participant(
@@ -137,6 +134,11 @@ class AudioStream:
             stream = self._create_owned_stream()
         self._ffi_handle = FfiHandle(stream.handle.id)
         self._info = stream.info
+
+        # Start _run only after _ffi_handle is set, so a failure above doesn't orphan
+        # a task that dereferences an unassigned _ffi_handle.
+        self._task = self._loop.create_task(self._run())
+        self._task.add_done_callback(task_done_logger)
 
         if self._track is not None:
             self._track._register_audio_stream(self)

--- a/livekit-rtc/tests/test_audio_stream_init.py
+++ b/livekit-rtc/tests/test_audio_stream_init.py
@@ -1,0 +1,53 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for AudioStream.__init__ error handling."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit import rtc
+
+
+async def test_failed_stream_creation_does_not_orphan_run_task() -> None:
+    """If owned-stream creation fails, __init__ must not leave a running _run task.
+
+    _run dereferences self._ffi_handle, which is only assigned once stream creation
+    succeeds. Scheduling the task before that assignment leaves an orphaned task that
+    raises AttributeError from the event loop, uncatchable by the caller.
+    """
+    track = MagicMock(spec=rtc.Track)
+    before = asyncio.all_tasks()
+
+    with patch.object(
+        rtc.AudioStream,
+        "_create_owned_stream",
+        side_effect=RuntimeError("track already closed"),
+    ):
+        with pytest.raises(RuntimeError, match="track already closed"):
+            rtc.AudioStream(track)
+
+    orphaned = [
+        t
+        for t in asyncio.all_tasks() - before
+        if getattr(t.get_coro(), "__qualname__", "") == "AudioStream._run"
+    ]
+    for t in orphaned:
+        t.cancel()
+
+    assert not orphaned


### PR DESCRIPTION
`AudioStream.__init__` kicks off the `_run` task before it creates the stream and sets `self._ffi_handle`. So if stream creation throws (e.g. the track got torn down when the participant dropped mid-setup), `__init__` raises like it should, but the `_run` task is already running and trips over the unset `self._ffi_handle` with `AttributeError: 'AudioStream' object has no attribute '_ffi_handle'`. It leaks as an unretrieved task exception on the `livekit` logger, so the caller can't catch it.

Fix is just to start the task after the handle is set. Nothing awaits in between so the order doesn't matter for correctness, and it lines up with `VideoStream`, which already does it this way.

Could also default `_ffi_handle` to `None` and guard `_is_event`, but that leaves a `_run` task spinning on a predicate that never matches, so I went with the reorder. Happy to switch if you'd rather. Test fails on the old order, passes now.

closes #729