### PR TITLE
python server SDK: add unified start_egress convenience method

### DIFF
--- a/livekit-api/livekit/api/egress_service.py
+++ b/livekit-api/livekit/api/egress_service.py
@@ -9,6 +9,7 @@ from livekit.protocol.egress import (
     UpdateStreamRequest,
     ListEgressRequest,
     StopEgressRequest,
+    StartEgressRequest,
     EgressInfo,
     ListEgressResponse,
 )
@@ -88,6 +89,16 @@ class EgressService(Service):
         return await self._client.request(
             SVC,
             "StartTrackEgress",
+            start,
+            self._auth_header(VideoGrants(room_record=True)),
+            EgressInfo,
+        )
+
+    async def start_egress(self, start: StartEgressRequest) -> EgressInfo:
+        """Starts an egress; the request's source and outputs determine the egress type."""
+        return await self._client.request(
+            SVC,
+            "StartEgress",
             start,
             self._auth_header(VideoGrants(room_record=True)),
             EgressInfo,

--- a/tests/api/test_livekitapi.py
+++ b/tests/api/test_livekitapi.py
@@ -194,6 +194,19 @@ async def _egress_smoke():
                 file=api.DirectFileOutput(filepath="track.mp4"),
             )
         )
+        await lk.egress.start_egress(
+            api.StartEgressRequest(
+                room_name="test-room",
+                web=api.WebSource(url="https://example.com/scene"),
+                outputs=[
+                    api.Output(
+                        file=api.FileOutput(
+                            file_type=api.EncodedFileType.MP4, filepath="unified.mp4"
+                        )
+                    )
+                ],
+            )
+        )
         await lk.egress.update_layout(
             api.UpdateLayoutRequest(egress_id="EG_abc123", layout="speaker")
         )


### PR DESCRIPTION
livekit-api (python) EgressService exposes a unified start_egress that calls the Egress.StartEgress RPC with the v2 StartEgressRequest
