### PR TITLE
fix(rtc): handle repeated local track subscription events

### DIFF
--- a/livekit-rtc/livekit/rtc/room.py
+++ b/livekit-rtc/livekit/rtc/room.py
@@ -814,7 +814,8 @@ class Room(EventEmitter[EventTypes]):
         elif which == "local_track_subscribed":
             sid = event.local_track_subscribed.track_sid
             lpublication = self.local_participant.track_publications[sid]
-            lpublication._first_subscription.set_result(None)
+            if not lpublication._first_subscription.done():
+                lpublication._first_subscription.set_result(None)
             self.emit("local_track_subscribed", lpublication.track)
         elif which == "track_published":
             # The participant may already have been removed by a racing

--- a/livekit-rtc/tests/test_audio_stream_room_lifecycle.py
+++ b/livekit-rtc/tests/test_audio_stream_room_lifecycle.py
@@ -550,6 +550,38 @@ def test_local_track_republished_updates_track_sid_and_repushes_metadata() -> No
     }
 
 
+@pytest.mark.asyncio
+async def test_repeated_local_track_subscribed_event_does_not_raise() -> None:
+    """A full reconnect can repeat local_track_subscribed for a publication
+    whose first-subscription future is already complete.
+    """
+    room = _make_room()
+    local = _make_local_participant("agent")
+    room._local_participant = local
+
+    track = _make_track(sid="TR_1")
+    publication = _make_local_publication(sid="TR_1")
+    publication._track = track
+    publication._first_subscription = asyncio.Future()
+    local._track_publications["TR_1"] = publication
+
+    subscribed_tracks: list[rtc.Track | None] = []
+
+    @room.on("local_track_subscribed")
+    def _on_local_track_subscribed(subscribed_track: rtc.Track | None) -> None:
+        subscribed_tracks.append(subscribed_track)
+
+    event = proto_room.RoomEvent(
+        local_track_subscribed=proto_room.LocalTrackSubscribed(track_sid="TR_1")
+    )
+    room._on_room_event(event)
+    await publication.wait_for_subscription()
+    room._on_room_event(event)
+
+    assert publication._first_subscription.done()
+    assert subscribed_tracks == [track, track]
+
+
 # -- unpublish_track / room-event race ----------------------------------------
 
 


### PR DESCRIPTION
Fixes #770

### Problem

During a full reconnect, the server can resend `local_track_subscribed` for a reused `LocalTrackPublication`. Its `_first_subscription` future is one-shot and already resolved, so calling `set_result(None)` again raises `asyncio.InvalidStateError`. `_listen_task` catches the exception, logs an error, and drops the repeated event.

### Fix

Only resolve `_first_subscription` while it is pending. The handler still emits `local_track_subscribed` for every event, preserving callback behavior across reconnects.

The regression test dispatches the same event twice and verifies both branches:

- the first event resolves `wait_for_subscription()`;
- the repeated event does not raise and is still delivered to listeners.

### Testing

- Regression test fails with `InvalidStateError` on the unguarded handler and passes with this change.
- `MACOSX_DEPLOYMENT_TARGET=11.0 uv run pytest livekit-rtc/tests -q` — 33 passed, 14 skipped.
- Ruff lint and format checks pass across the maintained Python packages and tests.
- Mypy passes across `livekit-protocol`, `livekit-api`, and `livekit-rtc/livekit`.
- `make build-wheel PACKAGE=livekit-rtc` succeeds.

The full root test command also reached 48 passed and 30 skipped. Three audio-fixture tests could not run locally because Git LFS was unavailable and the WAV fixtures remained pointer files; CI is configured to fetch those LFS assets.
