### PR TITLE
fix(api): require exp claim when verifying access tokens

### DIFF
--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -19,7 +19,7 @@ import os
 import jwt
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Optional, List, Literal
+from typing import Optional, List, Literal
 from google.protobuf.json_format import MessageToDict, ParseDict
 
 from livekit.protocol.room import RoomConfiguration
@@ -233,11 +233,13 @@ class TokenVerifier:
         if verify_signature and (not self.api_key or not self.api_secret):
             raise ValueError("api_key and api_secret must be set")
 
-        options: dict[str, Any] = {"verify_signature": verify_signature}
         # First-party minters always set exp. Without this, a hand-rolled token
         # with a valid signature and no exp verifies forever (livekit/protocol#1706).
-        if verify_signature:
-            options["require"] = ["exp"]
+        decode_options = (
+            {"verify_signature": True, "require": ["exp"]}
+            if verify_signature
+            else {"verify_signature": False}
+        )
 
         claims = jwt.decode(
             token,
@@ -245,7 +247,7 @@ class TokenVerifier:
             issuer=self.api_key or "",
             algorithms=["HS256"],
             leeway=self._leeway.total_seconds(),
-            options=options,
+            options=decode_options,
         )
         video_dict = claims.get("video", dict())
         video_dict = {camel_to_snake(k): v for k, v in video_dict.items()}

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -235,8 +235,6 @@ class TokenVerifier:
 
         # First-party minters always set exp. Without this, a hand-rolled token
         # with a valid signature and no exp verifies forever (livekit/protocol#1706).
-        # Inline each options literal so mypy matches PyJWT's Options TypedDict
-        # (a shared dict from a ternary widens to dict[str, object]).
         if verify_signature:
             claims = jwt.decode(
                 token,

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -19,7 +19,7 @@ import os
 import jwt
 import dataclasses
 from dataclasses import dataclass
-from typing import Optional, List, Literal
+from typing import Any, Optional, List, Literal
 from google.protobuf.json_format import MessageToDict, ParseDict
 
 from livekit.protocol.room import RoomConfiguration
@@ -233,7 +233,7 @@ class TokenVerifier:
         if verify_signature and (not self.api_key or not self.api_secret):
             raise ValueError("api_key and api_secret must be set")
 
-        options = {"verify_signature": verify_signature}
+        options: dict[str, Any] = {"verify_signature": verify_signature}
         # First-party minters always set exp. Without this, a hand-rolled token
         # with a valid signature and no exp verifies forever (livekit/protocol#1706).
         if verify_signature:

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -233,13 +233,19 @@ class TokenVerifier:
         if verify_signature and (not self.api_key or not self.api_secret):
             raise ValueError("api_key and api_secret must be set")
 
+        options = {"verify_signature": verify_signature}
+        # First-party minters always set exp. Without this, a hand-rolled token
+        # with a valid signature and no exp verifies forever (livekit/protocol#1706).
+        if verify_signature:
+            options["require"] = ["exp"]
+
         claims = jwt.decode(
             token,
             key=self.api_secret or "",
             issuer=self.api_key or "",
             algorithms=["HS256"],
             leeway=self._leeway.total_seconds(),
-            options={"verify_signature": verify_signature},
+            options=options,
         )
         video_dict = claims.get("video", dict())
         video_dict = {camel_to_snake(k): v for k, v in video_dict.items()}

--- a/livekit-api/livekit/api/access_token.py
+++ b/livekit-api/livekit/api/access_token.py
@@ -235,20 +235,26 @@ class TokenVerifier:
 
         # First-party minters always set exp. Without this, a hand-rolled token
         # with a valid signature and no exp verifies forever (livekit/protocol#1706).
-        decode_options = (
-            {"verify_signature": True, "require": ["exp"]}
-            if verify_signature
-            else {"verify_signature": False}
-        )
-
-        claims = jwt.decode(
-            token,
-            key=self.api_secret or "",
-            issuer=self.api_key or "",
-            algorithms=["HS256"],
-            leeway=self._leeway.total_seconds(),
-            options=decode_options,
-        )
+        # Inline each options literal so mypy matches PyJWT's Options TypedDict
+        # (a shared dict from a ternary widens to dict[str, object]).
+        if verify_signature:
+            claims = jwt.decode(
+                token,
+                key=self.api_secret or "",
+                issuer=self.api_key or "",
+                algorithms=["HS256"],
+                leeway=self._leeway.total_seconds(),
+                options={"verify_signature": True, "require": ["exp"]},
+            )
+        else:
+            claims = jwt.decode(
+                token,
+                key=self.api_secret or "",
+                issuer=self.api_key or "",
+                algorithms=["HS256"],
+                leeway=self._leeway.total_seconds(),
+                options={"verify_signature": False},
+            )
         video_dict = claims.get("video", dict())
         video_dict = {camel_to_snake(k): v for k, v in video_dict.items()}
         video_dict = {k: v for k, v in video_dict.items() if k in VideoGrants.__dataclass_fields__}

--- a/tests/api/test_access_token.py
+++ b/tests/api/test_access_token.py
@@ -1,5 +1,7 @@
+import calendar
 import datetime
 
+import jwt
 import pytest
 from livekit.api import AccessToken, TokenVerifier, VideoGrants, SIPGrants
 from livekit.protocol.room import RoomConfiguration
@@ -99,5 +101,18 @@ def test_verify_token_expired() -> None:
     token_verifier = TokenVerifier(
         TEST_API_KEY, TEST_API_SECRET, leeway=datetime.timedelta(seconds=0)
     )
+    with pytest.raises(Exception):
+        token_verifier.verify(token)
+
+
+def test_verify_token_missing_exp() -> None:
+    now = calendar.timegm(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
+    token = jwt.encode(
+        {"sub": "test_identity", "iss": TEST_API_KEY, "nbf": now},
+        TEST_API_SECRET,
+        algorithm="HS256",
+    )
+
+    token_verifier = TokenVerifier(TEST_API_KEY, TEST_API_SECRET)
     with pytest.raises(Exception):
         token_verifier.verify(token)


### PR DESCRIPTION
## Problem

`TokenVerifier.verify` decodes with issuer, HS256, and leeway, but does not require `exp`. PyJWT treats a missing `exp` as optional, so a hand-rolled token with a valid signature and no expiry verifies forever.

First-party `AccessToken.to_jwt` always sets `exp`. This matches the gap livekit/protocol#1706 closed on the Go verifier (`jwt.WithExpirationRequired`).

## Fix

When `verify_signature` is true (the production path), pass `require: ["exp"]`. `verify_signature=False` (simulate/dev) is unchanged.

Threat-model: the attacker can mint or obtain an HS256 token that omits `exp`. They do not control the verifier secret or clock. Without the claim, signature verification still succeeds and the credential never ages out. That is permanent access from a forgotten expiry, not host or agent authority.

## Test plan

- `pytest tests/api/test_access_token.py` (5/5)
- Revert-tested: removing `require: ["exp"]` makes `test_verify_token_missing_exp` fail (missing-exp token is accepted)

Made with [Cursor](https://cursor.com)