### PR TITLE
bumping pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -58,7 +58,7 @@ jobs:
           name: api-release
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   docs:
     needs: [publish]

--- a/.github/workflows/build-protocol.yml
+++ b/.github/workflows/build-protocol.yml
@@ -99,7 +99,7 @@ jobs:
           name: protocol-release
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   docs:
     needs: [publish]

--- a/.github/workflows/build-rtc.yml
+++ b/.github/workflows/build-rtc.yml
@@ -187,7 +187,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   docs:
     needs: [publish]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -279,7 +279,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # ── API build ────────────────────────────────────────────────
   build-api:
@@ -328,7 +328,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # ── Protocol build ───────────────────────────────────────────
   build-protocol:
@@ -377,7 +377,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # ── Docs ─────────────────────────────────────────────────────
   docs-rtc:


### PR DESCRIPTION
## Summary 
- Pushing the 1.1.23 version (https://github.com/livekit/python-sdks/pull/781) to PyPI failed because of `ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`.
- This bumps the pypi publish action to a later version that contains twine 7.0, which support metadata 2.5