### PR TITLE
chore(renovate): don't age-gate submodule digest bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,10 @@
       "matchManagers": ["git-submodules"],
       "matchDepNames": ["livekit-rtc/rust-sdks"],
       "enabled": false
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
Renovate detects the `livekit-protocol/protocol` submodule but has never opened a bump PR for it; every bump so far has been manual (#786, #780, #775, #763, #761). The Dependency Dashboard (#613) shows the update stuck under "Pending Status Checks".

Cause: the repo-wide `"minimumReleaseAge": "2 weeks"` also applies to the `git-submodules` manager, but submodule digest updates carry no release timestamp. Renovate's default `minimumReleaseAgeBehaviour` is `timestamp-required`, so a digest with no timestamp is treated as never old enough and the branch is never created.

This exempts the `git-submodules` manager from the age gate; everything else keeps the 2-week wait.

Verified with a local dry run (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=full RENOVATE_ENABLED_MANAGERS=git-submodules LOG_LEVEL=debug npx renovate`):

- main config: `digest update of livekit-protocol/protocol has no releaseTimestamp to age against` → `"pendingChecks": true` for `renovate/livekit-protocol-protocol-digest`
- this branch: `Branch is not pending, removing pending upgrades (branch=renovate/livekit-protocol-protocol-digest)`

`renovate-config-validator` passes.